### PR TITLE
Revert POP-1215 Use ecr cache for pr-agent image

### DIFF
--- a/Dockerfile.github_action_dockerhub
+++ b/Dockerfile.github_action_dockerhub
@@ -1,1 +1,1 @@
-FROM 221489699002.dkr.ecr.eu-central-1.amazonaws.com/docker-hub/codiumai/pr-agent:github_action
+FROM codiumai/pr-agent:github_action


### PR DESCRIPTION
Revert as permission to ECR is missing. Will be tested in other PR